### PR TITLE
Support for Year and Month

### DIFF
--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -1,0 +1,53 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Month;
+
+/**
+ *
+ * @author Björn Raupach
+ */
+public class MonthTypeHandler extends BaseTypeHandler<Month> {
+    
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Month month, JdbcType type) throws SQLException {
+        ps.setInt(i, month.getValue());
+    }
+
+    @Override
+    public Month getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int month = rs.getInt(columnName);
+        return month == 0 ? null : Month.of(month);
+    }
+
+    @Override
+    public Month getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int month = rs.getInt(columnIndex);
+        return month == 0 ? null : Month.of(month);
+    }
+
+    @Override
+    public Month getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int month = cs.getInt(columnIndex);
+        return month == 0 ? null : Month.of(month);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -1,0 +1,52 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Year;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearTypeHandler extends BaseTypeHandler<Year> {
+    
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Year year, JdbcType type) throws SQLException {
+        ps.setInt(i, year.getValue());
+    }
+
+    @Override
+    public Year getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int year = rs.getInt(columnName);
+        return year == 0 ? null : Year.of(year);
+    }
+
+    @Override
+    public Year getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int year = rs.getInt(columnIndex);
+        return year == 0 ? null : Year.of(year);
+    }
+
+    @Override
+    public Year getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int year = cs.getInt(columnIndex);
+        return year == 0 ? null : Year.of(year);
+    }
+    
+}


### PR DESCRIPTION
First of all, I would like to thank you for this project. Time to get rid of all the custom type handlers and use an official MyBatis extension!

We improved the readability of our code a lot by using `Year` and `Month` instead of passing `int` around in method signatures. Maybe support can be added as well.
