### PR TITLE
Support for YearMonth

### DIFF
--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,0 +1,58 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.YearMonth;
+
+/**
+ * Type Handler for {@link javax.time.YearMonth}
+ *
+ * YearMonthTypeHandler relies upon
+ * {@link javax.time.YearMonth#parse YearMonth.parse}. Therefore column values
+ * are expected as strings. The format must be uuuu-MM. Example: "2016-08"
+ *
+ * @author Björn Raupach
+ */
+public class YearMonthTypeHandler extends BaseTypeHandler<YearMonth> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, YearMonth yearMonth, JdbcType jt) throws SQLException {
+    ps.setString(i, yearMonth.toString());
+  }
+
+  @Override
+  public YearMonth getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    String value = rs.getString(columnName);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+  @Override
+  public YearMonth getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    String value = rs.getString(columnIndex);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+  @Override
+  public YearMonth getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    String value = cs.getString(columnIndex);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/YearMonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/YearMonthTypeHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.time.YearMonth;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<YearMonth> TYPE_HANDLER = new YearMonthTypeHandler();
+  private static final YearMonth INSTANT = YearMonth.now();
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+    verify(ps).setString(1, INSTANT.toString());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getString("column")).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getString(1)).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getString(1)).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}


### PR DESCRIPTION
We are using this YearMonthTypeHandler in production for a while and it might be a good addition to mybatis/typehandler-jsr310.

Since YearMonth depends upon a year value and a month value we expect column values as Strings in the format 'uuuu-mm'. We just feed this value YearMonth.parse.

Maybe someone could have a look at the UnitTests. I don't use Mockito so I had to look on the other unit test classes to make it work.
