### PR TITLE
Type handlers for Threeten-Extra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,14 @@
       <version>3.4.2</version>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threeten-extra</artifactId>
+      <version>1.0</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/apache/ibatis/type/AmPmTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/AmPmTypeHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.AmPm;
+
+/**
+ * Type Handler for threeten-extra AmPm
+ * 
+ * This type handler makes some assumptions on the data type of the column.
+ * If your RDBMS supports enums you are set.
+ * 
+ * @author Björn Raupach
+ */
+public class AmPmTypeHandler extends BaseTypeHandler<AmPm> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, AmPm amPm, JdbcType type) throws SQLException {
+        ps.setString(parameterIndex, amPm.name());
+    }
+
+    @Override
+    public AmPm getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String str = rs.getString(columnName);
+        return getAmPm(str);
+    }
+
+    @Override
+    public AmPm getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String str = rs.getString(columnIndex);
+        return getAmPm(str);
+    }
+
+    @Override
+    public AmPm getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String str = cs.getString(columnIndex);
+        return getAmPm(str);
+    }
+    
+    private static AmPm getAmPm(String str) {
+        if (str != null) {
+            return AmPm.valueOf(str);
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/DayOfMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DayOfMonthTypeHandler.java
@@ -1,0 +1,54 @@
+/**
+ *    Copyright 2016-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.DayOfMonth;
+
+/**
+ * Type Handler for threeten-extra DayOfMonth
+ * 
+ * @author Björn Raupach
+ */
+public class DayOfMonthTypeHandler extends BaseTypeHandler<DayOfMonth> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, DayOfMonth dayOfMonth, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, dayOfMonth.getValue());
+    }
+
+    @Override
+    public DayOfMonth getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int dayOfMonth = rs.getInt(columnName);
+        return dayOfMonth == 0 ? null : DayOfMonth.of(dayOfMonth);
+    }
+
+    @Override
+    public DayOfMonth getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int dayOfMonth = rs.getInt(columnIndex);
+        return dayOfMonth == 0 ? null : DayOfMonth.of(dayOfMonth);
+    }
+
+    @Override
+    public DayOfMonth getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int dayOfMonth = cs.getInt(columnIndex);
+        return dayOfMonth == 0 ? null : DayOfMonth.of(dayOfMonth);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/DayOfYearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DayOfYearTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.DayOfYear;
+
+/**
+ * Type Handler for threeten-extra DayOfYear
+ * 
+ * @author Björn Raupach
+ */
+public class DayOfYearTypeHandler extends BaseTypeHandler<DayOfYear> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, DayOfYear dayOfYear, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, dayOfYear.getValue());
+    }
+
+    @Override
+    public DayOfYear getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int dayOfYear = rs.getInt(columnName);
+        return dayOfYear == 0 ? null : DayOfYear.of(dayOfYear);
+    }
+
+    @Override
+    public DayOfYear getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int dayOfYear = rs.getInt(columnIndex);
+        return dayOfYear == 0 ? null : DayOfYear.of(dayOfYear);
+    }
+
+    @Override
+    public DayOfYear getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int dayOfYear = cs.getInt(columnIndex);
+        return dayOfYear == 0 ? null : DayOfYear.of(dayOfYear);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/DaysTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DaysTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Days;
+
+/**
+ * Type Handler for threeten-extra Days
+ * 
+ * @author Björn Raupach
+ */
+public class DaysTypeHandler extends BaseTypeHandler<Days> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Days days, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, days.getAmount());
+    }
+
+    @Override
+    public Days getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int days = rs.getInt(columnName);
+        return rs.wasNull() ? null : Days.of(days);
+    }
+
+    @Override
+    public Days getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int days = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Days.of(days);
+    }
+
+    @Override
+    public Days getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int days = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Days.of(days);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/HoursTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/HoursTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Hours;
+
+/**
+ * Type Handler for threeten-extra Hours
+ * 
+ * @author Björn Raupach
+ */
+public class HoursTypeHandler extends BaseTypeHandler<Hours> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Hours hours, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, hours.getAmount());
+    }
+
+    @Override
+    public Hours getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int hours = rs.getInt(columnName);
+        return rs.wasNull() ? null : Hours.of(hours);
+    }
+
+    @Override
+    public Hours getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int hours = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Hours.of(hours);
+    }
+
+    @Override
+    public Hours getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int hours = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Hours.of(hours);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/MinutesTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MinutesTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Minutes;
+
+/**
+ * Type Handler for threeten-extra Minutes
+ * 
+ * @author Björn Raupach
+ */
+public class MinutesTypeHandler extends BaseTypeHandler<Minutes> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Minutes minutes, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, minutes.getAmount());
+    }
+
+    @Override
+    public Minutes getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int minutes = rs.getInt(columnName);
+        return rs.wasNull() ? null : Minutes.of(minutes);
+    }
+
+    @Override
+    public Minutes getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int minutes = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Minutes.of(minutes);
+    }
+
+    @Override
+    public Minutes getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int minutes = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Minutes.of(minutes);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/MonthsTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthsTypeHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Months;
+
+/**
+ * Type handler for threeten-extra Months
+ * @author raupach
+ */
+public class MonthsTypeHandler extends BaseTypeHandler<Months> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Months months, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, months.getAmount());
+    }
+
+    @Override
+    public Months getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int months = rs.getInt(columnName);
+        return rs.wasNull() ? null : Months.of(months);
+    }
+
+    @Override
+    public Months getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int months = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Months.of(months);
+    }
+
+    @Override
+    public Months getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int months = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Months.of(months);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/QuarterTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/QuarterTypeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Quarter;
+
+/**
+ * Type Handler for threeten-extra Quarter
+ * 
+ * @author Björn Raupach
+ */
+public class QuarterTypeHandler extends BaseTypeHandler<Quarter> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Quarter quarter, JdbcType type) throws SQLException {
+        ps.setString(parameterIndex, quarter.name());
+    }
+
+    @Override
+    public Quarter getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String str = rs.getString(columnName);
+        return getQuarter(str);
+    }
+
+    @Override
+    public Quarter getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String str = rs.getString(columnIndex);
+        return getQuarter(str);
+    }
+
+    @Override
+    public Quarter getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String str = cs.getString(columnIndex);
+        return getQuarter(str);
+    }
+    
+    private static Quarter getQuarter(String str) {
+        if (str != null) {
+            return Quarter.valueOf(str);
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/WeeksTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/WeeksTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Weeks;
+
+/**
+ * Type handler for threeten-extra Weeks
+ * 
+ * @author Björn Raupach
+ */
+public class WeeksTypeHandler extends BaseTypeHandler<Weeks> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Weeks weeks, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, weeks.getAmount());
+    }
+
+    @Override
+    public Weeks getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int weeks = rs.getInt(columnName);
+        return rs.wasNull() ? null : Weeks.of(weeks);
+    }
+
+    @Override
+    public Weeks getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int weeks = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Weeks.of(weeks);
+    }
+
+    @Override
+    public Weeks getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int weeks = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Weeks.of(weeks);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/YearQuarterTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearQuarterTypeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.YearQuarter;
+
+/**
+ * Type Handler for threeten-extra YearQuarter
+ * 
+ * @author Björn Raupach
+ */
+public class YearQuarterTypeHandler extends BaseTypeHandler<YearQuarter> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, YearQuarter yearQuarter, JdbcType type) throws SQLException {
+        ps.setString(parameterIndex, yearQuarter.toString());
+    }
+
+    @Override
+    public YearQuarter getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String str = rs.getString(columnName);
+        return getYearQuarter(str);
+    }
+
+    @Override
+    public YearQuarter getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String str = rs.getString(columnIndex);
+        return getYearQuarter(str);
+    }
+
+    @Override
+    public YearQuarter getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String str = cs.getString(columnIndex);
+        return getYearQuarter(str);
+    }
+    
+    private static YearQuarter getYearQuarter(String str) {
+        if (str != null) {
+            return YearQuarter.parse(str);
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/YearWeekTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearWeekTypeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.YearWeek;
+
+/**
+ * Type Handler for threeten-extra YearWeek
+ * 
+ * @author Björn Raupach
+ */
+public class YearWeekTypeHandler extends BaseTypeHandler<YearWeek> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, YearWeek yearWeek, JdbcType type) throws SQLException {
+        ps.setString(parameterIndex, yearWeek.toString());
+    }
+
+    @Override
+    public YearWeek getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String str = rs.getString(columnName);
+        return getYearWeek(str);
+    }
+
+    @Override
+    public YearWeek getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String str = rs.getString(columnIndex);
+        return getYearWeek(str);
+    }
+
+    @Override
+    public YearWeek getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String str = cs.getString(columnIndex);
+        return getYearWeek(str);
+    }
+    
+    private static YearWeek getYearWeek(String str) {
+        if (str != null) {
+            return YearWeek.parse(str);
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/YearsTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearsTypeHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.threeten.extra.Years;
+
+/**
+ * Type handler for threeten-extra Years
+ * 
+ * @author Björn Raupach
+ */
+public class YearsTypeHandler extends BaseTypeHandler<Years> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int parameterIndex, Years years, JdbcType type) throws SQLException {
+        ps.setInt(parameterIndex, years.getAmount());
+    }
+
+    @Override
+    public Years getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int years = rs.getInt(columnName);
+        return rs.wasNull() ? null : Years.of(years);
+    }
+
+    @Override
+    public Years getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int years = rs.getInt(columnIndex);
+        return rs.wasNull() ? null : Years.of(years);
+    }
+
+    @Override
+    public Years getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int years = cs.getInt(columnIndex);
+        return cs.wasNull() ? null : Years.of(years);
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/AmPmTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/AmPmTypeHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.AmPm;
+import static org.threeten.extra.AmPm.*;
+
+
+/**
+ * @author Björn Raupach
+ */
+public class AmPmTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<AmPm> TYPE_HANDLER = new AmPmTypeHandler();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, AM, null);
+        verify(ps).setString(1, AM.name());
+        
+        TYPE_HANDLER.setParameter(ps, 1, PM, null);
+        verify(ps).setString(1, PM.name());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(AM.name());
+        assertEquals(AM, TYPE_HANDLER.getResult(rs, "column"));
+        
+        when(rs.getString("column")).thenReturn(PM.name());
+        assertEquals(PM, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(AM.name());
+        assertEquals(AM, TYPE_HANDLER.getResult(rs, 1));
+        
+        when(rs.getString(1)).thenReturn(PM.name());
+        assertEquals(PM, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(AM.name());
+        assertEquals(AM, TYPE_HANDLER.getResult(cs, 1));
+        
+        when(cs.getString(1)).thenReturn(PM.name());
+        assertEquals(PM, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowDateTimeException() throws Exception {
+        when(rs.getString("column")).thenReturn("some value");
+        ((AmPmTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/DayOfMonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DayOfMonthTypeHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ *    Copyright 2016-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.time.DateTimeException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.DayOfMonth;
+
+/**
+ * @author Björn Raupach
+ */
+public class DayOfMonthTypeHandlerTest extends BaseTypeHandlerTest {
+
+    private static final TypeHandler<DayOfMonth> TYPE_HANDLER = new DayOfMonthTypeHandler();
+    private static final DayOfMonth INSTANT = DayOfMonth.now();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getValue());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = DateTimeException.class)
+    public void shouldThrowDateTimeException() throws Exception {
+        when(rs.getInt("column")).thenReturn(999);
+        ((DayOfMonthTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/type/DayOfYearTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DayOfYearTypeHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.time.DateTimeException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.DayOfYear;
+
+/**
+ * @author Björn Raupach
+ */
+public class DayOfYearTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<DayOfYear> TYPE_HANDLER = new DayOfYearTypeHandler();
+    private static final DayOfYear INSTANT = DayOfYear.now();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getValue());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getValue());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = DateTimeException.class)
+    public void shouldThrowDateTimeException() throws Exception {
+        when(rs.getInt("column")).thenReturn(999);
+        ((DayOfYearTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/DaysTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DaysTypeHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Days;
+
+/**
+ * @author Björn Raupach
+ */
+public class DaysTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<Days> TYPE_HANDLER = new DaysTypeHandler();
+    private static final Days INSTANT = Days.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/HoursTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/HoursTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Hours;
+
+/**
+ * @author Björn Raupach
+ */
+public class HoursTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<Hours> TYPE_HANDLER = new HoursTypeHandler();
+    private static final Hours INSTANT = Hours.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    
+}

--- a/src/test/java/org/apache/ibatis/type/MinutesTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/MinutesTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Minutes;
+
+/**
+ *
+ * @author Björn Raupach
+ */
+public class MinutesTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<Minutes> TYPE_HANDLER = new MinutesTypeHandler();
+    private static final Minutes INSTANT = Minutes.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/MonthsTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/MonthsTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Months;
+
+/**
+ * @author Björn Raupach
+ */
+public class MonthsTypeHandlerTest extends BaseTypeHandlerTest {
+
+    private static final TypeHandler<Months> TYPE_HANDLER = new MonthsTypeHandler();
+    private static final Months INSTANT = Months.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    
+}

--- a/src/test/java/org/apache/ibatis/type/QuarterTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/QuarterTypeHandlerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Quarter;
+
+/**
+ * @author Björn Raupach
+ */
+public class QuarterTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<Quarter> TYPE_HANDLER = new QuarterTypeHandler();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        for (Quarter q : Quarter.values()) {
+            TYPE_HANDLER.setParameter(ps, 1, q, null);
+            verify(ps).setString(1, q.name());
+        }
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        for (Quarter q : Quarter.values()) {
+            when(rs.getString("column")).thenReturn(q.name());
+            assertEquals(q, TYPE_HANDLER.getResult(rs, "column"));
+        }
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        for (Quarter q : Quarter.values()) {
+            when(rs.getString(1)).thenReturn(q.name());
+            assertEquals(q, TYPE_HANDLER.getResult(rs, 1));
+        }
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        for (Quarter q : Quarter.values()) {
+            when(cs.getString(1)).thenReturn(q.name());
+            assertEquals(q, TYPE_HANDLER.getResult(cs, 1));
+        }
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldIllegalArgumentException() throws Exception {
+        when(rs.getString("column")).thenReturn("some value");
+        ((QuarterTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/WeeksTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/WeeksTypeHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Weeks;
+
+/**
+ * @author Björn Raupach
+ */
+public class WeeksTypeHandlerTest extends BaseTypeHandlerTest {
+
+    private static final TypeHandler<Weeks> TYPE_HANDLER = new WeeksTypeHandler();
+    private static final Weeks INSTANT = Weeks.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/YearQuarterTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/YearQuarterTypeHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.time.DateTimeException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.YearQuarter;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearQuarterTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<YearQuarter> TYPE_HANDLER = new YearQuarterTypeHandler();
+    private static final YearQuarter INSTANT = YearQuarter.now();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setString(1, INSTANT.toString());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = DateTimeException.class)
+    public void shouldThrowDateTimeException() throws Exception {
+        when(rs.getString("column")).thenReturn("some value");
+        ((YearQuarterTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/YearWeekTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/YearWeekTypeHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.time.DateTimeException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.YearWeek;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearWeekTypeHandlerTest extends BaseTypeHandlerTest {
+    
+    private static final TypeHandler<YearWeek> TYPE_HANDLER = new YearWeekTypeHandler();
+    private static final YearWeek INSTANT = YearWeek.now();
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setString(1, INSTANT.toString());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getString("column")).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(INSTANT.toString());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getString(1)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+    @Test(expected = DateTimeException.class)
+    public void shouldThrowDateTimeException() throws Exception {
+        when(rs.getString("column")).thenReturn("some value");
+        ((YearWeekTypeHandler)TYPE_HANDLER).getNullableResult(rs, "column");
+    }
+    
+}

--- a/src/test/java/org/apache/ibatis/type/YearsTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/YearsTypeHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.threeten.extra.Years;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearsTypeHandlerTest extends BaseTypeHandlerTest {
+
+    private static final TypeHandler<Years> TYPE_HANDLER = new YearsTypeHandler();
+    private static final Years INSTANT = Years.ZERO;
+
+    @Override
+    @Test
+    public void shouldSetParameter() throws Exception {
+        TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+        verify(ps).setInt(1, INSTANT.getAmount());
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByName() throws Exception {
+        when(rs.getInt("column")).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+        when(rs.getInt(1)).thenReturn(0);
+        when(rs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(rs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(INSTANT.getAmount());
+        assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    }
+
+    @Override
+    @Test
+    public void shouldGetResultNullFromCallableStatement() throws Exception {
+        when(cs.getInt(1)).thenReturn(0);
+        when(cs.wasNull()).thenReturn(true);
+        assertNull(TYPE_HANDLER.getResult(cs, 1));
+    }
+    
+}


### PR DESCRIPTION
[ThreeTen-Extra](http://www.threeten.org/threeten-extra/index.html) provides additional date-time classes that complement those in Java SE 8.

I have found most of these classes very useful. It gives your entities, domain objects, whatever you call them, more semantic properties. For example you can store an amount of days in a `Days` class instead of a plain int.

## New Type Handlers

This pull request adds type handlers for the following classes from ThreeTen-Extra:

* AmPm
* DayOfMonth
* DayOfYear
* Days
* Hours
* Minutes
* Months
* Weeks
* YearQuarter
* Years
* YearWeek
* Quarter

There is a corresponding unit test with each class. I admit to a lot of copy&pasterino.

## Implementation notes

Most classes of java.time have some matching database datatype: java.time.LocalTime to java.sql.Time. Unfortunately this is not possible with every class from ThreeTen-Extra.

The classes `AmPm` and `Quarter` are enums. Therefore the database column are expected to be some CHAR or VARCHAR type. The value ist stored as the name() of the enum.  Can't speak for all databases but most do have some kind of enum datatype that makes storage efficient.

The classes YearQuarter and YearWeek are expected to be stored in CHAR / VARCHAR columns as well. For example: '2017-Q1' and '2017-W3'. Given that the values need some special format there can a parsing exception if some other application writes data to that column.  For example '2017Q1' wouldn't be parseable by `YearQuarter.parse`. The type handler would throw an `DateTimeException` in that case. I think this is totally fine, but we could also wrap it in some MyBatis specific exception. Not sure what the general approach to exceptions in type handlers is. 

## Optional dependency

Since not everyone is using threeten-extra, or doesn't want to use it, I added it via an optional dependency. Not nice to force some compile time dependency. Therefore using these typehandlers requires threeten.extra in your pom.xml.








